### PR TITLE
fix: docker compose -> docker-compose 로 변경

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -74,5 +74,5 @@ jobs:
           script: |
             echo ${{ env.DOCKER_HUB_TOKEN }} | docker login -u ${{ env.DOCKER_HUB_USERNAME }} --password-stdin
             docker pull ${{ env.DOCKER_HUB_USERNAME }}/jwt-security:latest
-            docker compose -f ./docker-compose-deploy.yml down
-            docker compose -f ./docker-compose-deploy.yml up -d
+            docker-compose -f ./docker-compose-deploy.yml down
+            docker-compose -f ./docker-compose-deploy.yml up -d


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #2

## 📝작업 내용

> docker compose -> docker-compose 로 변경
우분투에서 어떤 Docker 버전을 다운 받아도 쓸 수 있게 변경했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Docker Compose command syntax in GitHub Actions workflow for deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->